### PR TITLE
add example reverse-proxy test

### DIFF
--- a/test/example/reverse_proxy_test.go
+++ b/test/example/reverse_proxy_test.go
@@ -1,0 +1,39 @@
+//go:build example
+// + build example
+
+package example_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aileron-gateway/aileron-gateway/kernel/testutil"
+)
+
+func TestReverseProxy(t *testing.T) {
+
+	env := []string{}
+	config := []string{"../../_example/reverse-proxy/"}
+	entrypoint := getEntrypointRunner(t, env, config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	timer := time.AfterFunc(5*time.Second, cancel)
+
+	var resp *http.Response
+	var err error
+	go func(){
+		req, _ := http.NewRequest(http.MethodGet, "http://localhost:8080/", nil)
+		resp, err = http.DefaultTransport.RoundTrip(req)
+		timer.Stop()
+		cancel()
+	}()
+
+	if err:=entrypoint.Run(ctx); err!=nil{
+		t.Error(err)
+	}
+	
+	testutil.Diff(t, nil, err)
+	testutil.Diff(t, http.StatusOK, resp.StatusCode)
+}


### PR DESCRIPTION
# Summary of Changes
Added tests for _example/reverse-proxy.

# Details of Changes
The path to config.yaml in the existing test code for access logging has been changed to use _example/reverse-proxy.

# Verification Method
Run the following command:
`go test -tags example test/example/reverse_proxy_test.go test/example/common_test.go`

# Issues
None.