### PR TITLE
always set vary header when accept-encoding exists

### DIFF
--- a/app/middleware/compression/middleware.go
+++ b/app/middleware/compression/middleware.go
@@ -57,6 +57,13 @@ func (c *compression) Middleware(next http.Handler) http.Handler {
 		// See the RFC7231 for possible formats of the Accept-Encoding headers.
 		// 	- https://datatracker.ietf.org/doc/rfc7231/
 		encoding := r.Header.Get("Accept-Encoding")
+		if encoding == "" {
+			next.ServeHTTP(w, r) // Skip response compression.
+			return
+		}
+
+		// Always add the Vary header for cache control.
+		w.Header().Add("Vary", "Accept-Encoding")
 
 		switch {
 		case strings.Contains(encoding, brotliEncoding): // Brotli compression.

--- a/app/middleware/compression/middleware_test.go
+++ b/app/middleware/compression/middleware_test.go
@@ -43,6 +43,21 @@ func TestCompressionMiddleware(t *testing.T) {
 	gen := testutil.NewCase[*condition, *action]
 	testCases := []*testutil.Case[*condition, *action]{
 		gen(
+			"accept header not exist",
+			[]string{},
+			[]string{},
+			&condition{
+				acceptEncoding: "",
+				encoding:       "",
+				contentType:    "text/plain",
+				body:           []byte("test response body"),
+			},
+			&action{
+				encoding: "",
+				body:     "test response body",
+			},
+		),
+		gen(
 			"accept gzip",
 			[]string{},
 			[]string{},
@@ -193,7 +208,9 @@ func TestCompressionMiddleware(t *testing.T) {
 			})
 
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
-			req.Header.Set("Accept-Encoding", tt.C().acceptEncoding)
+			if tt.C().acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tt.C().acceptEncoding)
+			}
 			resp := httptest.NewRecorder()
 			comp.Middleware(h).ServeHTTP(resp, req)
 

--- a/app/middleware/compression/writer.go
+++ b/app/middleware/compression/writer.go
@@ -120,9 +120,8 @@ func (w *compressionWriter) initialize() {
 		ce = w.encoding
 	}
 
-	wh.Add("Vary", "Accept-Encoding") // Don't let client use cached content when required for different types of encoding.
-	wh.Set("Content-Encoding", ce)    // Set the encoding by replacing existing one.
-	wh.Del("Content-Length")          // Delete Content-Length because the content will be compressed.
+	wh.Set("Content-Encoding", ce) // Set the encoding by replacing existing one.
+	wh.Del("Content-Length")       // Delete Content-Length because the content will be compressed.
 	w.writer.Reset(w.ResponseWriter)
 }
 


### PR DESCRIPTION

### What type of PR is this?

- [x] enhancement (add options to feature, improve performance, refactoring, etc)


### Related issue(s)
<!--
Link related issues.

`Fixes #<issue number>` or `Fixes (paste link of issue)`
`Closes #<issue number>` or `Closes (paste link of issue)`
-->

### Does this PR break user interface?
<!--
If no, just write "NONE" in the release-note block below.
If yes, write release note below.
-->
```release-note
In CompressionMiddleware
Vary: Accept-Encoding 
header is always set when an Accept-Encoding header exists in request.
```

### Description of this PR

In CompressionMiddleware
Vary: Accept-Encoding 
header is always set when an Accept-Encoding header exists in request.

### Notes for reviewer(s)
