### PR TITLE
Fix apt install to install qemu

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -57,9 +57,10 @@ jobs:
         with:
           go-version: stable
       - run: |
+          # See https://launchpad.net/~canonical-server
           # sudo add-apt-repository -y ppa:canonical-server/server-backports
-          sudo apt -y update
-          sudo apt -y install qemu-user
+          sudo apt-get -y update
+          sudo apt-get -y install qemu-user
       - name: make test
         run: |
           make go-test-qemu GOARCH=${{ matrix.arch }} GO_TEST_TARGET=./test/integration/... EXTRA_ARGS="-tags=integration"

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -57,7 +57,7 @@ jobs:
         with:
           go-version: stable
       - run: |
-          sudo add-apt-repository -y ppa:canonical-server/server-backports
+          # sudo add-apt-repository -y ppa:canonical-server/server-backports
           sudo apt -y update
           sudo apt -y install qemu-user
       - name: make test

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -69,7 +69,8 @@ jobs:
         with:
           go-version: stable
       - run: |
-          sudo add-apt-repository -y ppa:canonical-server/server-backports
+          # sudo add-apt-repository -y ppa:canonical-server/server-backports
+          sudo add-apt-repository -y ppa:canonical-server
           sudo apt -y update
           sudo apt -y install qemu-user
       - name: make test

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -69,9 +69,10 @@ jobs:
         with:
           go-version: stable
       - run: |
+          # See https://launchpad.net/~canonical-server
           # sudo add-apt-repository -y ppa:canonical-server/server-backports
-          sudo apt -y update
-          sudo apt -y install qemu-user
+          sudo apt-get -y update
+          sudo apt-get -y install qemu-user
       - name: make test
         run: |
           make go-test-qemu GOARCH=${{ matrix.arch }}	GO_TEST_TARGET=./cmd/...

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -70,7 +70,6 @@ jobs:
           go-version: stable
       - run: |
           # sudo add-apt-repository -y ppa:canonical-server/server-backports
-          sudo add-apt-repository -y ppa:canonical-server
           sudo apt -y update
           sudo apt -y install qemu-user
       - name: make test


### PR DESCRIPTION
## What type of PR is this?

<!-- Choose one or more types of this PR. -->
- [ ] documentation.
- [ ] bug fix.
- [ ] adding or removing a feature.
- [ ] enhancement (adding options, improve performance, refactoring, etc).
- [x] testing (adding, removing or fixing tests etc)
- [ ] release.
- [ ] others.

## Related issues
<!--
Link related issues.
`Fixes #<issue number>` or `Fixes (paste link of issue)`
`Closes #<issue number>` or `Closes (paste link of issue)`
-->

## Does this PR break user interface?

<!--If yes, write release note below.-->
- [ ] Yes.
- [x] No.

```release-note

```

## Description of this PR


`sudo add-apt-repository -y ppa:canonical-server/server-backports`

make it possible to install the latest `qemu-user ` package
buit it sometimes fails with 504 Gateway Timeout.

So remove it.

## Notes for reviewers
