### PR TITLE
Replace protoreflect.ProtoMessage to proto.Message

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,8 +28,8 @@ linters:
     gocyclo:
       min-complexity: 20
     gosec:
-      # Temporary excludes "G117", "G705", "G703", "G706"
-      excludes: ["G110", "G401", "G404", "G405", "G501", "G502", "G503", "G505", "G117", "G705", "G703", "G706"]
+      # Temporary excludes "G117", "G705", "G703", "G706", "G704", "G118"
+      excludes: ["G110", "G401", "G404", "G405", "G501", "G502", "G503", "G505", "G117", "G705", "G703", "G706", "G704", "G118"]
     govet:
       disable:
         - fieldalignment

--- a/CHANGELOG/1.2.x/CHANGELOG-1.2.0.md
+++ b/CHANGELOG/1.2.x/CHANGELOG-1.2.0.md
@@ -5,7 +5,6 @@ Table of contents.
 - [Versions](#versions)
 - [Changes](#changes)
   - [Breaking changes](#breaking-changes)
-  - [New features](#new-features)
   - [Bug fix, Security fix](#bug-fix-security-fix)
   - [Other changes](#other-changes)
 - [Dependencies](#dependencies)
@@ -13,6 +12,7 @@ Table of contents.
   - [Changed](#changed)
   - [Removed](#removed)
 - [Migration guides](#migration-guides)
+  - [#121](#121)
 
 ## Versions
 
@@ -32,8 +32,7 @@ Table of contents.
 - [#111](https://github.com/aileron-gateway/aileron-gateway/pull/111): Move kernel/network package to internal/network (@k7a-tomohiro)
 - [#112](https://github.com/aileron-gateway/aileron-gateway/pull/112): Move util/security package to internal/security (@k7a-tomohiro)
 - [#114](https://github.com/aileron-gateway/aileron-gateway/pull/114): Move util/session package to kernel/session (@k7a-tomohiro)
-
-### New features
+- [#121](https://github.com/aileron-gateway/aileron-gateway/pull/121): Replace protoreflect.ProtoMessage to proto.Message (@k7a-tomohiro)
 
 _Nothing has changed._
 
@@ -66,4 +65,6 @@ _Nothing has changed._
 
 ## Migration guides
 
-_Migration is not required._
+### [#121](https://github.com/aileron-gateway/aileron-gateway/pull/121)
+
+Replace all [protoreflect.ProtoMessage](https://pkg.go.dev/google.golang.org/protobuf/reflect/protoreflect#ProtoMessage) by [proto.Message](https://pkg.go.dev/google.golang.org/protobuf/proto#Message).

--- a/app/authn/authn/api.go
+++ b/app/authn/authn/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -38,7 +38,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.AuthenticationMiddleware)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/app/authn/basic/api.go
+++ b/app/authn/basic/api.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -52,7 +52,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.BasicAuthnMiddleware)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/app/authn/digest/api.go
+++ b/app/authn/digest/api.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -53,7 +53,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.DigestAuthnMiddleware)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/app/authn/idkey/api.go
+++ b/app/authn/idkey/api.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -56,7 +56,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.IDKeyAuthnMiddleware)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/app/authn/key/api.go
+++ b/app/authn/key/api.go
@@ -18,7 +18,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -53,7 +53,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.KeyAuthnMiddleware)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/app/authn/oauth/api.go
+++ b/app/authn/oauth/api.go
@@ -20,7 +20,6 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/golang-jwt/jwt/v5"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -57,7 +56,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.OAuthAuthenticationHandler)
 
 	for name, spec := range c.Spec.Contexts {
@@ -91,7 +90,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	var err error
 
 	skipATValidation, err = getEnvAsBool("AILERON_SKIP_AT_VALIDATION", false)

--- a/app/authn/oauth/api_internal_test.go
+++ b/app/authn/oauth/api_internal_test.go
@@ -15,17 +15,17 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -178,7 +178,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/handler/echo/api.go
+++ b/app/handler/echo/api.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -35,7 +35,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.EchoHandler)
 
 	return &echo{

--- a/app/handler/healthcheck/api.go
+++ b/app/handler/healthcheck/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/core"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -46,7 +46,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.HealthCheckHandler)
 
 	if len(c.Spec.Patterns) == 0 {
@@ -56,7 +56,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HealthCheckHandler)
 
 	eh, err := utilhttp.ErrorHandler(a, c.Spec.ErrorHandler)

--- a/app/handler/healthcheck/api_internal_test.go
+++ b/app/handler/healthcheck/api_internal_test.go
@@ -18,19 +18,19 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
 		err        any
 		errPattern *regexp.Regexp
-		expect     protoreflect.ProtoMessage
+		expect     proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -94,7 +94,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/bodylimit/api.go
+++ b/app/middleware/bodylimit/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -43,7 +43,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.BodyLimitMiddleware)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))
 

--- a/app/middleware/bodylimit/api_test.go
+++ b/app/middleware/bodylimit/api_test.go
@@ -14,12 +14,12 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/compression/api.go
+++ b/app/middleware/compression/api.go
@@ -9,7 +9,7 @@ import (
 	v1 "github.com/aileron-gateway/aileron-gateway/apis/app/v1"
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -45,7 +45,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.CompressionMiddleware)
 
 	if len(c.Spec.TargetMIMEs) == 0 {
@@ -64,7 +64,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.CompressionMiddleware)
 
 	gzipLevel := restrictBetween(int(c.Spec.GzipLevel), 1, 9)      // BestSpeed=1, BestCompression=9.

--- a/app/middleware/compression/api_test.go
+++ b/app/middleware/compression/api_test.go
@@ -15,16 +15,16 @@ import (
 	"github.com/andybalholm/brotli"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -74,7 +74,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/cors/api.go
+++ b/app/middleware/cors/api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -48,7 +48,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.CORSMiddleware)
 
 	// Set default values for CORS policy.
@@ -68,7 +68,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.CORSMiddleware)
 	_ = log.DefaultOr(c.Metadata.Logger)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))

--- a/app/middleware/cors/api_test.go
+++ b/app/middleware/cors/api_test.go
@@ -16,16 +16,16 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -71,7 +71,7 @@ func TestMutate(t *testing.T) {
 }
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/csrf/api.go
+++ b/app/middleware/csrf/api.go
@@ -20,7 +20,6 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -61,7 +60,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.CSRFMiddleware)
 
 	if len(c.Spec.Patterns) == 0 {
@@ -93,7 +92,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.CSRFMiddleware)
 	_ = log.DefaultOr(c.Metadata.Logger)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))

--- a/app/middleware/csrf/api_test.go
+++ b/app/middleware/csrf/api_test.go
@@ -19,17 +19,17 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	host, _ := os.Hostname()
@@ -313,7 +313,7 @@ func TestMutate(t *testing.T) {
 func TestCreate(t *testing.T) {
 
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/csrf/token.go
+++ b/app/middleware/csrf/token.go
@@ -31,7 +31,7 @@ type csrfToken struct {
 }
 
 func (h *csrfToken) new() (string, error) {
-	seed := make([]byte, h.seedSize)
+	seed := make([]byte, h.seedSize) //nolint:prealloc // Consider preallocating seed with capacity h.seedSize + len(digest)
 	if _, err := io.ReadFull(rand.Reader, seed); err != nil {
 		return "", err
 	}

--- a/app/middleware/header/api.go
+++ b/app/middleware/header/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/internal/txtutil"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -40,7 +40,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HeaderPolicyMiddleware)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))
 

--- a/app/middleware/header/api_test.go
+++ b/app/middleware/header/api_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/aileron-projects/go/zerrors"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/headercert/api.go
+++ b/app/middleware/headercert/api.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -48,7 +48,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HeaderCertMiddleware)
 	_ = log.DefaultOr(c.Metadata.Logger)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))

--- a/app/middleware/headercert/api_test.go
+++ b/app/middleware/headercert/api_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/session/api.go
+++ b/app/middleware/session/api.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	"github.com/aileron-gateway/aileron-gateway/kernel/session"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -60,7 +60,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.SessionMiddleware)
 	_ = log.DefaultOr(c.Metadata.Logger)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))

--- a/app/middleware/soaprest/api.go
+++ b/app/middleware/soaprest/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-projects/go/zencoding/zxml"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 )
@@ -31,7 +31,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (s *API) Default() protoreflect.ProtoMessage {
+func (s *API) Default() proto.Message {
 	return &v1.SOAPRESTMiddleware{
 		APIVersion: apiVersion,
 		Kind:       kind,
@@ -43,7 +43,7 @@ func (s *API) Default() protoreflect.ProtoMessage {
 	}
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.SOAPRESTMiddleware)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))
 

--- a/app/middleware/soaprest/api_test.go
+++ b/app/middleware/soaprest/api_test.go
@@ -15,12 +15,12 @@ import (
 	"github.com/aileron-projects/go/zencoding/zxml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/throttle/api.go
+++ b/app/middleware/throttle/api.go
@@ -16,7 +16,6 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/aileron-projects/go/ztime/zrate"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -48,7 +47,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.ThrottleMiddleware)
 	for _, t := range c.Spec.APIThrottlers {
 		switch t := t.Throttlers.(type) {
@@ -85,7 +84,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.ThrottleMiddleware)
 	_ = log.DefaultOr(c.Metadata.Logger)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))

--- a/app/middleware/throttle/api_test.go
+++ b/app/middleware/throttle/api_test.go
@@ -17,17 +17,17 @@ import (
 	"github.com/aileron-projects/go/ztime/zrate"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -195,7 +195,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/timeout/api.go
+++ b/app/middleware/timeout/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/internal/txtutil"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -40,7 +40,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.TimeoutMiddleware)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))
 

--- a/app/middleware/timeout/api_test.go
+++ b/app/middleware/timeout/api_test.go
@@ -18,12 +18,12 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/middleware/tracking/api.go
+++ b/app/middleware/tracking/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -38,7 +38,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.TrackingMiddleware)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))
 	return &tracker{

--- a/app/middleware/tracking/api_test.go
+++ b/app/middleware/tracking/api_test.go
@@ -11,12 +11,12 @@ import (
 	k "github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/internal/testutil"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/opa/api.go
+++ b/app/opa/api.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-policy-agent/opa/loader"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -53,7 +53,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.OPAAuthzMiddleware)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/app/opa/api_test.go
+++ b/app/opa/api_test.go
@@ -12,12 +12,12 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/core"
 	"github.com/aileron-gateway/aileron-gateway/internal/testutil"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/otelmeter/api.go
+++ b/app/otelmeter/api.go
@@ -24,7 +24,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -49,7 +49,7 @@ type API struct {
 // Returned configuration does not contain all default values.
 // For example, default values for "repeated" or "oneof" fields in proto are set in mutate function.
 // Use "--template" command option to show configuration with all default values.
-func (o *API) Default() protoreflect.ProtoMessage {
+func (o *API) Default() proto.Message {
 	return &v1.OpenTelemetryMeter{
 		APIVersion: apiVersion,
 		Kind:       kind,
@@ -71,7 +71,7 @@ func (o *API) Default() protoreflect.ProtoMessage {
 	}
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.OpenTelemetryMeter)
 
 	var exporter sdkmetric.Exporter

--- a/app/otelmeter/api_internal_test.go
+++ b/app/otelmeter/api_internal_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/core"
 	"github.com/aileron-gateway/aileron-gateway/internal/testutil"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/oteltracer/api.go
+++ b/app/oteltracer/api.go
@@ -30,7 +30,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -47,7 +47,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (o *API) Default() protoreflect.ProtoMessage {
+func (o *API) Default() proto.Message {
 	return &v1.OpenTelemetryTracer{
 		APIVersion: apiVersion,
 		Kind:       kind,
@@ -81,7 +81,7 @@ func (o *API) Default() protoreflect.ProtoMessage {
 	}
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.OpenTelemetryTracer)
 
 	var exporter sdktrace.SpanExporter

--- a/app/oteltracer/api_internal_test.go
+++ b/app/oteltracer/api_internal_test.go
@@ -21,12 +21,12 @@ import (
 	"go.opentelemetry.io/contrib/propagators/opencensus"
 	"go.opentelemetry.io/contrib/propagators/ot"
 	"go.opentelemetry.io/otel/propagation"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/prommeter/api.go
+++ b/app/prommeter/api.go
@@ -11,7 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -43,7 +43,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.PrometheusMeter)
 
 	if len(c.Spec.Patterns) == 0 {
@@ -53,7 +53,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.PrometheusMeter)
 
 	reg := prometheus.NewRegistry()

--- a/app/prommeter/api_internal_test.go
+++ b/app/prommeter/api_internal_test.go
@@ -17,16 +17,16 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/prometheus/client_golang/prometheus"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -95,7 +95,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/app/skipper/api.go
+++ b/app/skipper/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -40,7 +40,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.Skipper)
 
 	ms, err := api.ReferTypedObjects[core.Middleware](a, c.Spec.Middleware...)

--- a/app/storage/redis/api.go
+++ b/app/storage/redis/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/internal/network"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/redis/go-redis/v9"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -57,7 +57,7 @@ type API struct {
 // Changes for the fields of msg in this function make the final values which will be the input for validate and create function.
 // Default values for "repeated" or "oneof" fields can also be applied in this function if necessary.
 // Please check msg!=nil and asserting the mgs does not panic even they won't from the view of overall architecture of the gateway.
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.RedisClient)
 
 	if len(c.Spec.Addrs) == 0 {
@@ -67,7 +67,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.RedisClient)
 
 	var tls *tls.Config

--- a/app/storage/redis/api_test.go
+++ b/app/storage/redis/api_test.go
@@ -11,16 +11,16 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/internal/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]

--- a/core/entrypoint/api.go
+++ b/core/entrypoint/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -40,14 +40,14 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.Entrypoint)
 	c.Metadata.Namespace = ".entrypoint" // Prevent users from overwriting this value.
 	c.Metadata.Name = ".entrypoint"      // Prevent users from overwriting this value.
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.Entrypoint)
 
 	var initializers []core.Initializer

--- a/core/entrypoint/api_internal_test.go
+++ b/core/entrypoint/api_internal_test.go
@@ -20,16 +20,16 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -116,7 +116,7 @@ func (f *testFinalizer) Finalize() error {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/core/errhandler/api.go
+++ b/core/errhandler/api.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -37,7 +37,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.ErrorHandler)
 
 	messages := make([]*utilhttp.ErrorMessage, 0, len(c.Spec.ErrorMessages))

--- a/core/errhandler/api_internal_test.go
+++ b/core/errhandler/api_internal_test.go
@@ -17,12 +17,12 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 		server   api.API[*api.Request, *api.Response]
 	}
 

--- a/core/goplugin/api.go
+++ b/core/goplugin/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/core"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -41,7 +41,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	err := errors.New("GoPlugin is not available in this build")
 	return nil, core.ErrCoreGenCreateObject.WithStack(err, map[string]any{"kind": kind})
 }

--- a/core/goplugin/api_cgo.go
+++ b/core/goplugin/api_cgo.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/aileron-projects/go/zplugin"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"github.com/golang/protobuf/proto"
 )
 
 const (
@@ -44,7 +44,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.GoPlugin)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/core/goplugin/api_internal_test.go
+++ b/core/goplugin/api_internal_test.go
@@ -15,13 +15,13 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/core/httpclient/api.go
+++ b/core/httpclient/api.go
@@ -13,7 +13,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/internal/network"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -40,7 +40,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HTTPClient)
 
 	var roundTripper http.RoundTripper = network.DefaultHTTPTransport

--- a/core/httpclient/api_internal_test.go
+++ b/core/httpclient/api_internal_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 // testDir is the path to the test data.
@@ -30,7 +30,7 @@ var testDir = "../../test/"
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/core/httphandler/api.go
+++ b/core/httphandler/api.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/core"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -41,7 +41,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HTTPHandler)
 
 	ms, err := api.ReferTypedObjects[core.Middleware](a, c.Spec.Middleware...)

--- a/core/httphandler/api_internal_test.go
+++ b/core/httphandler/api_internal_test.go
@@ -17,7 +17,7 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 type testHandler struct {
@@ -35,7 +35,7 @@ func (h *testHandler) Methods() []string {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 		server   api.API[*api.Request, *api.Response]
 	}
 

--- a/core/httplogger/api.go
+++ b/core/httplogger/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -49,7 +49,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.HTTPLogger)
 
 	// Set default journal MIMEs.
@@ -83,7 +83,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HTTPLogger)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/core/httplogger/api_internal_test.go
+++ b/core/httplogger/api_internal_test.go
@@ -22,16 +22,16 @@ import (
 	"github.com/aileron-projects/go/ztext"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -101,7 +101,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 		server   api.API[*api.Request, *api.Response]
 	}
 

--- a/core/httpproxy/api.go
+++ b/core/httpproxy/api.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aileron-projects/go/zx/zlb"
 	"github.com/cespare/xxhash/v2"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -48,7 +47,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.ReverseProxyHandler)
 	for _, spec := range c.Spec.LoadBalancers {
 		for j, t := range spec.Upstreams {
@@ -64,7 +63,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.ReverseProxyHandler)
 	eh := utilhttp.GlobalErrorHandler(cmp.Or(c.Metadata.ErrorHandler, utilhttp.DefaultErrorHandlerName))
 

--- a/core/httpproxy/api_internal_test.go
+++ b/core/httpproxy/api_internal_test.go
@@ -25,16 +25,16 @@ import (
 	"github.com/cespare/xxhash/v2"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -130,7 +130,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/core/httpserver/api.go
+++ b/core/httpserver/api.go
@@ -22,7 +22,7 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -59,7 +59,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.HTTPServer)
 
 	// Add "h2" to the NextProtos if HTTP2 server is enabled.
@@ -74,7 +74,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.HTTPServer)
 
 	lg := log.DefaultOr(c.Metadata.Logger)

--- a/core/httpserver/api_internal_test.go
+++ b/core/httpserver/api_internal_test.go
@@ -29,16 +29,16 @@ import (
 	"github.com/quic-go/quic-go/http3"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -121,7 +121,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/core/slogger/api.go
+++ b/core/slogger/api.go
@@ -19,7 +19,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/log"
 	"github.com/aileron-projects/go/zlog"
 	"github.com/aileron-projects/go/ztime/zcron"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -57,7 +57,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(_ api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(_ api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.SLogger)
 
 	timeZone, err := time.LoadLocation(c.Spec.LogOutput.TimeZone)

--- a/core/slogger/api_internal_test.go
+++ b/core/slogger/api_internal_test.go
@@ -25,12 +25,12 @@ import (
 	"github.com/aileron-projects/go/ztime/zcron"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {

--- a/core/static/api.go
+++ b/core/static/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/apis/kernel"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -41,7 +41,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.StaticFileHandler)
 	var fs http.FileSystem = http.Dir(path.Clean(c.Spec.RootDir))
 	if !c.Spec.EnableListing {

--- a/core/static/api_internal_test.go
+++ b/core/static/api_internal_test.go
@@ -18,7 +18,7 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 // testDir is the path to the test data.
@@ -26,7 +26,7 @@ var testDir = "../../test/"
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 		server   api.API[*api.Request, *api.Response]
 		path     string
 	}

--- a/core/template/api.go
+++ b/core/template/api.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/core"
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -39,7 +39,7 @@ type API struct {
 	*api.BaseResource
 }
 
-func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (*API) Mutate(msg proto.Message) proto.Message {
 	c := msg.(*v1.TemplateHandler)
 	for _, mc := range c.Spec.MIMEContents {
 		if mc.MIMEType == "" {
@@ -52,7 +52,7 @@ func (*API) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
 	return c
 }
 
-func (*API) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*v1.TemplateHandler)
 
 	contents := make([]*utilhttp.MIMEContent, 0, len(c.Spec.MIMEContents))

--- a/core/template/api_internal_test.go
+++ b/core/template/api_internal_test.go
@@ -18,16 +18,16 @@ import (
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMutate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	type action struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 	}
 
 	gen := testutil.NewCase[*condition, *action]
@@ -121,7 +121,7 @@ func TestMutate(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	type condition struct {
-		manifest protoreflect.ProtoMessage
+		manifest proto.Message
 		server   api.API[*api.Request, *api.Response]
 	}
 

--- a/docs/kernel/api.md
+++ b/docs/kernel/api.md
@@ -102,11 +102,11 @@ Here, resources are defined with this interface.
 
 ```go
 type Resource interface {
-  Default() protoreflect.ProtoMessage
-  Validate(protoreflect.ProtoMessage) error
-  Mutate(protoreflect.ProtoMessage) protoreflect.ProtoMessage
-  Create(API[*Request, *Response], protoreflect.ProtoMessage) (any, error)
-  Delete(API[*Request, *Response], protoreflect.ProtoMessage, any) error
+  Default() proto.Message
+  Validate(proto.Message) error
+  Mutate(proto.Message) proto.Message
+  Create(API[*Request, *Response], proto.Message) (any, error)
+  Delete(API[*Request, *Response], proto.Message, any) error
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.2.0
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/golang-jwt/jwt/v5 v5.3.0
+	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/lestrrat-go/jwx/v2 v2.1.6

--- a/internal/encoder/proto.go
+++ b/internal/encoder/proto.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aileron-projects/go/zerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // MarshalProto marshal proto message into byte array.
@@ -18,7 +17,7 @@ import (
 //	opt := proto.MarshalOptions{
 //		AllowPartial: true,
 //	}
-func MarshalProto(in protoreflect.ProtoMessage, opt *proto.MarshalOptions) ([]byte, error) {
+func MarshalProto(in proto.Message, opt *proto.MarshalOptions) ([]byte, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -44,7 +43,7 @@ func MarshalProto(in protoreflect.ProtoMessage, opt *proto.MarshalOptions) ([]by
 //		AllowPartial:   true,
 //		DiscardUnknown: false,
 //	}
-func UnmarshalProto(in []byte, into protoreflect.ProtoMessage, opt *proto.UnmarshalOptions) error {
+func UnmarshalProto(in []byte, into proto.Message, opt *proto.UnmarshalOptions) error {
 	if into == nil {
 		return nil
 	}
@@ -70,7 +69,7 @@ func UnmarshalProto(in []byte, into protoreflect.ProtoMessage, opt *proto.Unmars
 //		AllowPartial:   true,
 //		DiscardUnknown: false,
 //	}
-func UnmarshalProtoFromJSON(in []byte, into protoreflect.ProtoMessage, opt *protojson.UnmarshalOptions) error {
+func UnmarshalProtoFromJSON(in []byte, into proto.Message, opt *protojson.UnmarshalOptions) error {
 	if into == nil {
 		return nil
 	}
@@ -98,7 +97,7 @@ func UnmarshalProtoFromJSON(in []byte, into protoreflect.ProtoMessage, opt *prot
 //		UseEnumNumbers:  false,
 //		EmitUnpopulated: false,
 //	}
-func MarshalProtoToJSON(in protoreflect.ProtoMessage, opt *protojson.MarshalOptions) ([]byte, error) {
+func MarshalProtoToJSON(in proto.Message, opt *protojson.MarshalOptions) ([]byte, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -128,7 +127,7 @@ func MarshalProtoToJSON(in protoreflect.ProtoMessage, opt *protojson.MarshalOpti
 //		AllowPartial:   true,
 //		DiscardUnknown: false,
 //	}
-func UnmarshalProtoFromYAML(in []byte, into protoreflect.ProtoMessage, opt *protojson.UnmarshalOptions) error {
+func UnmarshalProtoFromYAML(in []byte, into proto.Message, opt *protojson.UnmarshalOptions) error {
 	if into == nil {
 		return nil
 	}
@@ -159,7 +158,7 @@ func UnmarshalProtoFromYAML(in []byte, into protoreflect.ProtoMessage, opt *prot
 //		UseEnumNumbers:  false,
 //		EmitUnpopulated: false,
 //	}
-func MarshalProtoToYAML(in protoreflect.ProtoMessage, opt *protojson.MarshalOptions) ([]byte, error) {
+func MarshalProtoToYAML(in proto.Message, opt *protojson.MarshalOptions) ([]byte, error) {
 	if in == nil {
 		return nil, nil
 	}

--- a/internal/encoder/proto_internal_test.go
+++ b/internal/encoder/proto_internal_test.go
@@ -11,12 +11,12 @@ import (
 	"github.com/aileron-projects/go/zerrors"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestMarshalProto(t *testing.T) {
 	type condition struct {
-		in protoreflect.ProtoMessage
+		in proto.Message
 	}
 
 	type action struct {
@@ -63,11 +63,11 @@ func TestMarshalProto(t *testing.T) {
 func TestUnmarshalProto(t *testing.T) {
 	type condition struct {
 		in   string
-		into protoreflect.ProtoMessage
+		into proto.Message
 	}
 
 	type action struct {
-		result protoreflect.ProtoMessage
+		result proto.Message
 		err    error
 	}
 
@@ -123,11 +123,11 @@ func TestUnmarshalProto(t *testing.T) {
 func TestUnmarshalProtoFromJSON(t *testing.T) {
 	type condition struct {
 		in   string
-		into protoreflect.ProtoMessage
+		into proto.Message
 	}
 
 	type action struct {
-		result protoreflect.ProtoMessage
+		result proto.Message
 		err    error
 	}
 
@@ -182,7 +182,7 @@ func TestUnmarshalProtoFromJSON(t *testing.T) {
 
 func TestMarshalProtoToJSON(t *testing.T) {
 	type condition struct {
-		in  protoreflect.ProtoMessage
+		in  proto.Message
 		opt *protojson.MarshalOptions
 	}
 
@@ -241,11 +241,11 @@ func TestMarshalProtoToJSON(t *testing.T) {
 func TestUnmarshalProtoFromYAML(t *testing.T) {
 	type condition struct {
 		in   string
-		into protoreflect.ProtoMessage
+		into proto.Message
 	}
 
 	type action struct {
-		result protoreflect.ProtoMessage
+		result proto.Message
 		err    error
 	}
 
@@ -300,7 +300,7 @@ func TestUnmarshalProtoFromYAML(t *testing.T) {
 
 func TestMarshalProtoToYAML(t *testing.T) {
 	type condition struct {
-		in  protoreflect.ProtoMessage
+		in  proto.Message
 		opt *protojson.MarshalOptions
 	}
 

--- a/kernel/api/common.go
+++ b/kernel/api/common.go
@@ -18,7 +18,6 @@ import (
 	"github.com/aileron-projects/go/zos"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 const (
@@ -66,8 +65,8 @@ type Format string
 const (
 	FormatJSON           Format = "JSON"           // JSON []byte
 	FormatYAML           Format = "YAML"           // YAML []byte
-	FormatProtoMessage   Format = "ProtoMessage"   // protoreflect.ProtoMessage
-	FormatProtoReference Format = "ProtoReference" // protoreflect.ProtoMessage only for kernel.Reference
+	FormatProtoMessage   Format = "ProtoMessage"   // proto.Message
+	FormatProtoReference Format = "ProtoReference" // proto.Message only for kernel.Reference
 )
 
 // Unmarshal un-marshals the in to into with this format.
@@ -194,11 +193,11 @@ func RootAPIFromContext(ctx context.Context) API[*Request, *Response] {
 	return routes[0]
 }
 
-// ProtoMessage returns protoreflect.ProtoMessage by parsing the given content.
+// ProtoMessage returns proto.Message by parsing the given content.
 // Typically, the defaultMsg is the configuration for API resources with default value
 // in protobuf message type.
 // defaultMsg will be ignored when the format is api.FormatProtoReference.
-func ProtoMessage(format Format, content any, defaultMsg protoreflect.ProtoMessage, opt *protojson.UnmarshalOptions) (protoreflect.ProtoMessage, error) {
+func ProtoMessage(format Format, content any, defaultMsg proto.Message, opt *protojson.UnmarshalOptions) (proto.Message, error) {
 	msg := defaultMsg
 	var err error
 	switch format {
@@ -227,13 +226,13 @@ func ProtoMessage(format Format, content any, defaultMsg protoreflect.ProtoMessa
 		err = encoder.UnmarshalProtoFromYAML(b, src, opt)
 		proto.Merge(msg, src)
 	case FormatProtoMessage:
-		src, ok := content.(protoreflect.ProtoMessage)
+		src, ok := content.(proto.Message)
 		if !ok {
 			return nil, zerrors.NewErr(nil, "kernel/api: type assertion failed.", "convert from %T to ProtoMessage", content)
 		}
 		proto.Merge(msg, src)
 	case FormatProtoReference:
-		src, ok := content.(protoreflect.ProtoMessage)
+		src, ok := content.(proto.Message)
 		if !ok {
 			return nil, zerrors.NewErr(nil, "kernel/api: type assertion failed.", "convert from %T to ProtoMessage", content)
 		}
@@ -258,7 +257,7 @@ func ProtoMessage(format Format, content any, defaultMsg protoreflect.ProtoMessa
 //			Namespace string `json:"namespace"`
 //		} `json:"metadata"`
 //	}
-func ParseID(msg protoreflect.ProtoMessage) (string, error) {
+func ParseID(msg proto.Message) (string, error) {
 	into := &struct {
 		Metadata *struct {
 			Name      string `json:"name"`

--- a/kernel/api/common_test.go
+++ b/kernel/api/common_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aileron-projects/go/zerrors"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestFormat_Unmarshal(t *testing.T) {
@@ -220,12 +220,12 @@ func TestProtoMessage(t *testing.T) {
 	type condition struct {
 		format  api.Format
 		content any
-		msg     protoreflect.ProtoMessage
+		msg     proto.Message
 		opt     *protojson.UnmarshalOptions
 	}
 
 	type action struct {
-		msg protoreflect.ProtoMessage
+		msg proto.Message
 		err error
 	}
 
@@ -464,7 +464,7 @@ func TestProtoMessage(t *testing.T) {
 
 func TestParseID(t *testing.T) {
 	type condition struct {
-		msg protoreflect.ProtoMessage
+		msg proto.Message
 	}
 
 	type action struct {
@@ -513,7 +513,7 @@ func TestParseID(t *testing.T) {
 		),
 		gen(
 			"nil pointer message", &condition{
-				msg: *new(protoreflect.ProtoMessage),
+				msg: *new(proto.Message),
 			},
 			&action{
 				id:  "",

--- a/kernel/api/factory.go
+++ b/kernel/api/factory.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aileron-projects/go/zerrors"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // KeyAccept is the key of the parameter.
@@ -26,23 +25,23 @@ const KeyAccept = "Accept"
 // Resources are used by being registered to a FactoryAPI.
 type Resource interface {
 	// Default returns a new instance of ProtoMessage with default values.
-	Default() protoreflect.ProtoMessage
+	Default() proto.Message
 	// Mutate changes the given ProtoMessage if necessary
 	// and return the changed ProtoMessage.
 	// Given ProtoMessage has the same type as the one returned by the Default().
 	// Input message is the merged with the default value and
 	// user defined configurations.
-	Mutate(protoreflect.ProtoMessage) protoreflect.ProtoMessage
+	Mutate(proto.Message) proto.Message
 	// Validate validates the given ProtoMessage
 	// and return an error when it was invalid.
 	// Given ProtoMessage has the same type as the one returned by the Default().
-	Validate(protoreflect.ProtoMessage) error
+	Validate(proto.Message) error
 	// Create creates a new instance of the resource.
 	// Given ProtoMessage has the same type as the one returned by the Default().
-	Create(API[*Request, *Response], protoreflect.ProtoMessage) (any, error)
+	Create(API[*Request, *Response], proto.Message) (any, error)
 	// Delete deletes the created resource.
 	// Given ProtoMessage has the same type as the one returned by the Default().
-	Delete(API[*Request, *Response], protoreflect.ProtoMessage, any) error
+	Delete(API[*Request, *Response], proto.Message, any) error
 }
 
 // BaseResource is the base struct for api.Resource interface.
@@ -51,14 +50,14 @@ type Resource interface {
 // This struct does not implement Create method because the method is
 // required by all resource implementations.
 type BaseResource struct {
-	DefaultProto protoreflect.ProtoMessage
+	DefaultProto proto.Message
 }
 
-func (b *BaseResource) Default() protoreflect.ProtoMessage {
+func (b *BaseResource) Default() proto.Message {
 	return proto.Clone(b.DefaultProto)
 }
 
-func (b *BaseResource) Validate(msg protoreflect.ProtoMessage) error {
+func (b *BaseResource) Validate(msg proto.Message) error {
 	v, _ := protovalidate.New()
 	if err := v.Validate(msg); err != nil {
 		json, _ := encoder.MarshalProtoToJSON(msg, &protojson.MarshalOptions{Multiline: true, Indent: "  ", AllowPartial: true})
@@ -67,11 +66,11 @@ func (b *BaseResource) Validate(msg protoreflect.ProtoMessage) error {
 	return nil
 }
 
-func (b *BaseResource) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (b *BaseResource) Mutate(msg proto.Message) proto.Message {
 	return msg
 }
 
-func (b *BaseResource) Delete(_ API[*Request, *Response], _ protoreflect.ProtoMessage, _ any) error {
+func (b *BaseResource) Delete(_ API[*Request, *Response], _ proto.Message, _ any) error {
 	return nil
 }
 
@@ -89,7 +88,7 @@ func addLineNumber(in []byte) []byte {
 // NewFactoryAPI returns a new instance of FactoryAPI.
 func NewFactoryAPI() *FactoryAPI {
 	return &FactoryAPI{
-		protoStore: map[string]protoreflect.ProtoMessage{},
+		protoStore: map[string]proto.Message{},
 		objStore:   map[string]any{},
 		resources:  map[string]Resource{},
 	}
@@ -102,7 +101,7 @@ func NewFactoryAPI() *FactoryAPI {
 type FactoryAPI struct {
 	// protoStore stores proto messages.
 	// The key will be IDs in the format of "APIGroup/APIVersion/Kind/Namespace/Name".
-	protoStore map[string]protoreflect.ProtoMessage
+	protoStore map[string]proto.Message
 	// objStore stores objects created by resources.
 	// The key will be IDs in the format of "APIGroup/APIVersion/Kind/Namespace/Name".
 	objStore map[string]any

--- a/kernel/api/factory_internal_test.go
+++ b/kernel/api/factory_internal_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aileron-projects/go/zerrors"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestNewFactoryAPI(t *testing.T) {
@@ -30,7 +30,7 @@ func TestNewFactoryAPI(t *testing.T) {
 			&condition{},
 			&action{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{},
+					protoStore: map[string]proto.Message{},
 					objStore:   map[string]any{},
 					resources:  map[string]Resource{},
 				},
@@ -52,11 +52,11 @@ type noopResource struct {
 	ID string // To make this struct comparative in the test.
 }
 
-func (r *noopResource) Default() protoreflect.ProtoMessage {
+func (r *noopResource) Default() proto.Message {
 	return nil
 }
 
-func (r *noopResource) Create(a API[*Request, *Response], msg protoreflect.ProtoMessage) (any, error) {
+func (r *noopResource) Create(a API[*Request, *Response], msg proto.Message) (any, error) {
 	return nil, nil
 }
 
@@ -142,11 +142,11 @@ type testResource struct {
 	err error
 }
 
-func (r *testResource) Default() protoreflect.ProtoMessage {
+func (r *testResource) Default() proto.Message {
 	return &k.Resource{}
 }
 
-func (r *testResource) Create(a API[*Request, *Response], msg protoreflect.ProtoMessage) (any, error) {
+func (r *testResource) Create(a API[*Request, *Response], msg proto.Message) (any, error) {
 	if msg == nil {
 		return nil, r.err
 	}
@@ -154,15 +154,15 @@ func (r *testResource) Create(a API[*Request, *Response], msg protoreflect.Proto
 	return c.Metadata.Namespace + " " + c.Metadata.Name, r.err
 }
 
-func (r *testResource) Validate(msg protoreflect.ProtoMessage) error {
+func (r *testResource) Validate(msg proto.Message) error {
 	return r.err
 }
 
-func (r *testResource) Mutate(msg protoreflect.ProtoMessage) protoreflect.ProtoMessage {
+func (r *testResource) Mutate(msg proto.Message) proto.Message {
 	return msg
 }
 
-func (r *testResource) Delete(a API[*Request, *Response], msg protoreflect.ProtoMessage, obj any) error {
+func (r *testResource) Delete(a API[*Request, *Response], msg proto.Message, obj any) error {
 	return r.err
 }
 
@@ -174,7 +174,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 	}
 
 	type action struct {
-		protoStore map[string]protoreflect.ProtoMessage
+		protoStore map[string]proto.Message
 		objStore   map[string]any
 		err        error
 	}
@@ -194,7 +194,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 			},
 		),
@@ -202,7 +202,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 			"Delete object",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{"test1/test2/test3/test4": &k.Reference{}},
+					protoStore: map[string]proto.Message{"test1/test2/test3/test4": &k.Reference{}},
 					objStore:   map[string]any{"test1/test2/test3/test4": "test3 test4"},
 				},
 				resource: &testResource{},
@@ -214,7 +214,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 			},
 		),
@@ -231,7 +231,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 				err:        &zerrors.Err{Message: "kernel/api: type assertion failed."},
 			},
@@ -249,7 +249,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 				err:        &zerrors.Err{Message: "kernel/api: type assertion failed."},
 			},
@@ -266,7 +266,7 @@ func TestFactoryAPI_delete(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 				err:        &zerrors.Err{Message: "internal/encoder: unmarshaling json failed."},
 			},
@@ -294,7 +294,7 @@ func TestFactoryAPI_post(t *testing.T) {
 	}
 
 	type action struct {
-		protoStore map[string]protoreflect.ProtoMessage
+		protoStore map[string]proto.Message
 		objStore   map[string]any
 		err        error
 	}
@@ -314,7 +314,7 @@ func TestFactoryAPI_post(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{
+				protoStore: map[string]proto.Message{
 					"test1/test2/test3/test4": &k.Resource{
 						APIVersion: "test1",
 						Kind:       "test2",
@@ -331,7 +331,7 @@ func TestFactoryAPI_post(t *testing.T) {
 			"duplicate key",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{"test1/test2/test3/test4": nil},
+					protoStore: map[string]proto.Message{"test1/test2/test3/test4": nil},
 				},
 				resource: &testResource{},
 				req: &Request{
@@ -342,7 +342,7 @@ func TestFactoryAPI_post(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{"test1/test2/test3/test4": nil},
+				protoStore: map[string]proto.Message{"test1/test2/test3/test4": nil},
 				err:        &zerrors.Err{Message: "kernel/api: key duplication error."},
 			},
 		),
@@ -359,7 +359,7 @@ func TestFactoryAPI_post(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 				err:        &zerrors.Err{Message: "kernel/api: type assertion failed."},
 			},
@@ -377,7 +377,7 @@ func TestFactoryAPI_post(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 				err:        &zerrors.Err{Message: "kernel/api: type assertion failed."},
 			},
@@ -394,7 +394,7 @@ func TestFactoryAPI_post(t *testing.T) {
 				},
 			},
 			&action{
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				objStore:   map[string]any{},
 				err:        &zerrors.Err{Message: "internal/encoder: unmarshaling json failed."},
 			},
@@ -423,7 +423,7 @@ func TestFactoryAPI_get(t *testing.T) {
 
 	type action struct {
 		obj        any
-		protoStore map[string]protoreflect.ProtoMessage
+		protoStore map[string]proto.Message
 		objStore   map[string]any
 		err        error
 	}
@@ -434,7 +434,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			"Get new instance",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{
+					protoStore: map[string]proto.Message{
 						"test1/test2/test3/test4": &k.Resource{
 							APIVersion: "test1",
 							Kind:       "test2",
@@ -456,7 +456,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				obj: "test3 test4",
-				protoStore: map[string]protoreflect.ProtoMessage{
+				protoStore: map[string]proto.Message{
 					"test1/test2/test3/test4": &k.Resource{
 						APIVersion: "test1",
 						Kind:       "test2",
@@ -473,7 +473,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			"Get existing instance",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{
+					protoStore: map[string]proto.Message{
 						"test1/test2/test3/test4": &k.Resource{
 							APIVersion: "test1",
 							Kind:       "test2",
@@ -495,7 +495,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				obj: "test3 test4",
-				protoStore: map[string]protoreflect.ProtoMessage{
+				protoStore: map[string]proto.Message{
 					"test1/test2/test3/test4": &k.Resource{
 						APIVersion: "test1",
 						Kind:       "test2",
@@ -512,7 +512,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			"accept as json",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{
+					protoStore: map[string]proto.Message{
 						"test1/test2/test3/test4": &k.Resource{
 							APIVersion: "test1",
 							Kind:       "test2",
@@ -534,7 +534,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				obj: "<<< Do not check this value because single space and double spaces are randomly used for marshalling ProtoMessage to JSON >>>",
-				protoStore: map[string]protoreflect.ProtoMessage{
+				protoStore: map[string]proto.Message{
 					"test1/test2/test3/test4": &k.Resource{
 						APIVersion: "test1",
 						Kind:       "test2",
@@ -550,7 +550,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			"accept as yaml",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{
+					protoStore: map[string]proto.Message{
 						"test1/test2/test3/test4": &k.Resource{
 							APIVersion: "test1",
 							Kind:       "test2",
@@ -572,7 +572,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				obj: []byte("apiVersion: test1\nkind: test2\nmetadata:\n  errorHandler: \"\"\n  logger: \"\"\n  name: test4\n  namespace: test3\nspec: null\n"),
-				protoStore: map[string]protoreflect.ProtoMessage{
+				protoStore: map[string]proto.Message{
 					"test1/test2/test3/test4": &k.Resource{
 						APIVersion: "test1",
 						Kind:       "test2",
@@ -589,7 +589,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			"accept as proto message",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{
+					protoStore: map[string]proto.Message{
 						"test1/test2/test3/test4": &k.Resource{
 							APIVersion: "test1",
 							Kind:       "test2",
@@ -618,7 +618,7 @@ func TestFactoryAPI_get(t *testing.T) {
 						Name:      "test4",
 					},
 				},
-				protoStore: map[string]protoreflect.ProtoMessage{
+				protoStore: map[string]proto.Message{
 					"test1/test2/test3/test4": &k.Resource{
 						APIVersion: "test1",
 						Kind:       "test2",
@@ -651,7 +651,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			"Get fails",
 			&condition{
 				a: &FactoryAPI{
-					protoStore: map[string]protoreflect.ProtoMessage{"test1/test2/test3/test4": nil},
+					protoStore: map[string]proto.Message{"test1/test2/test3/test4": nil},
 				},
 				resource: &testResource{err: &zerrors.Err{Message: ""}}, // Use APIError for dummy.
 				req: &Request{
@@ -663,7 +663,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				objStore:   nil,
-				protoStore: map[string]protoreflect.ProtoMessage{"test1/test2/test3/test4": nil},
+				protoStore: map[string]proto.Message{"test1/test2/test3/test4": nil},
 				err:        &zerrors.Err{Message: ""},
 			},
 		),
@@ -681,7 +681,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				objStore:   map[string]any{},
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				err:        &zerrors.Err{Message: "kernel/api: type assertion failed."},
 			},
 		),
@@ -698,7 +698,7 @@ func TestFactoryAPI_get(t *testing.T) {
 			},
 			&action{
 				objStore:   map[string]any{},
-				protoStore: map[string]protoreflect.ProtoMessage{},
+				protoStore: map[string]proto.Message{},
 				err:        &zerrors.Err{Message: "internal/encoder: unmarshaling json failed."},
 			},
 		),

--- a/kernel/api/factory_test.go
+++ b/kernel/api/factory_test.go
@@ -13,14 +13,14 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	"github.com/aileron-projects/go/zerrors"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/proto"
 )
 
 type MyResource struct {
 	*api.BaseResource
 }
 
-func (r *MyResource) Default() protoreflect.ProtoMessage {
+func (r *MyResource) Default() proto.Message {
 	// Use template message for this example.
 	return &k.Resource{
 		APIVersion: "factory/v1",
@@ -32,7 +32,7 @@ func (r *MyResource) Default() protoreflect.ProtoMessage {
 	}
 }
 
-func (r *MyResource) Create(a api.API[*api.Request, *api.Response], msg protoreflect.ProtoMessage) (any, error) {
+func (r *MyResource) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (any, error) {
 	c := msg.(*k.Resource)
 	// Just return the namespace and name values in the manifest
 	// because the kernel.Template message does not contain any meaningful fields


### PR DESCRIPTION
## What type of PR is this?

- [ ] new feature
- [ ] enhance feature
- [x] refactoring, performance tuning
- [ ] bug fix
- [ ] security fix
- [ ] testing
- [ ] documentation
- [ ] release
- [ ] others

## Related issues

<!--
Fixes `#<issue number>` or `(paste link of issue)`
Closes `#<issue number>` or `(paste link of issue)`
-->

## Does this PR break user interface?

- [x] Yes <!-- Fill the release-note -->
  - [x] Did you add [CHANGELOG](CHANGELOG/)?
  - [x] Did you add migration guides in [CHANGELOG](CHANGELOG/)?
- [ ] No
  - [ ] Did you add [CHANGELOG](CHANGELOG/)? (if necessary)

## Description

Replace [protoreflect.ProtoMessage](https://pkg.go.dev/google.golang.org/protobuf/reflect/protoreflect#ProtoMessage) by [proto.Message](https://pkg.go.dev/google.golang.org/protobuf/proto#Message).

## Notes for reviewers
