### PR TITLE
Fix http method routing 

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,7 +29,7 @@ linters:
       min-complexity: 20
     gosec:
       # Temporary excludes "G117", "G705", "G703", "G706", "G704", "G118"
-      excludes: ["G110", "G401", "G404", "G405", "G501", "G502", "G503", "G505", "G117", "G705", "G703", "G706", "G704", "G118"]
+      excludes: ["G110","G124", "G401", "G404", "G405", "G501", "G502", "G503", "G505", "G117", "G705", "G703", "G706", "G704", "G118"]
     govet:
       disable:
         - fieldalignment

--- a/core/httpserver/api.go
+++ b/core/httpserver/api.go
@@ -85,18 +85,8 @@ func (*API) Create(a api.API[*api.Request, *api.Response], msg proto.Message) (a
 	registerExpvar(mux, c.Spec.EnableExpvar)
 
 	nfh := notFoundHandler(eh)
-	handlers, err := registerHandlers(a, mux, c.Spec.VirtualHosts, nfh)
-	if err != nil {
+	if err := registerHandlers(a, mux, c.Spec.VirtualHosts, nfh); err != nil {
 		return nil, core.ErrCoreGenCreateObject.WithStack(err, map[string]any{"kind": kind})
-	}
-
-	// Register not found handler if possible.
-	skipNotFound := false
-	for k := range handlers {
-		skipNotFound = skipNotFound || wildcardPath.MatchString(k)
-	}
-	if !skipNotFound {
-		mux.Handle("/", notFoundHandler(eh))
 	}
 
 	middleware, err := api.ReferTypedObjects[core.Middleware](a, c.Spec.Middleware...)

--- a/core/httpserver/api_internal_test.go
+++ b/core/httpserver/api_internal_test.go
@@ -873,10 +873,10 @@ type testMux struct {
 }
 
 func (m *testMux) Handle(path string, h http.Handler) {
-	m.hs[path] = h
 	if m.Mux != nil {
 		m.Mux.Handle(path, h)
 	}
+	m.hs[path] = h
 }
 
 func (m *testMux) Method(string, string, http.Handler) {}

--- a/core/httpserver/mux.go
+++ b/core/httpserver/mux.go
@@ -6,7 +6,6 @@ package httpserver
 import (
 	"net/http"
 	"path"
-	"regexp"
 	"slices"
 	"strings"
 
@@ -15,23 +14,6 @@ import (
 	"github.com/aileron-gateway/aileron-gateway/kernel/api"
 	utilhttp "github.com/aileron-gateway/aileron-gateway/util/http"
 )
-
-// wildcardPath is the pattern matched to the
-// path pattern that will be matched to all path.
-//
-//	fmt.Println(wildcardPath.MatchString(""))                   // true
-//	fmt.Println(wildcardPath.MatchString("/"))                  // true
-//	fmt.Println(wildcardPath.MatchString("/{foo...}"))          // true
-//	fmt.Println(wildcardPath.MatchString("/{foo...}/"))         // true
-//	fmt.Println(wildcardPath.MatchString("/bar"))               // false
-//	fmt.Println(wildcardPath.MatchString("/bar/"))              // false
-//	fmt.Println(wildcardPath.MatchString("/bar/{foo...}"))      // false
-//	fmt.Println(wildcardPath.MatchString("/bar/{foo...}/"))     // false
-//	fmt.Println(wildcardPath.MatchString("/bar/baz"))           // false
-//	fmt.Println(wildcardPath.MatchString("/bar/baz/"))          // false
-//	fmt.Println(wildcardPath.MatchString("/bar/{foo...}/baz"))  // false
-//	fmt.Println(wildcardPath.MatchString("/bar/{foo...}/baz/")) // false
-var wildcardPath = regexp.MustCompile(`^/?({[^/]*\.\.\.}|$)`)
 
 // notFoundHandler returns a not found handler.
 // The returned handler will panic if the nil error handler was given.
@@ -50,7 +32,7 @@ type Mux interface {
 
 // registerHandlers register virtual host handlers to the given mux..
 // The function panics if the mux is nil.
-func registerHandlers(a api.API[*api.Request, *api.Response], mux Mux, specs []*v1.VirtualHostSpec, notFound http.Handler) (handlers map[string]http.Handler, err error) {
+func registerHandlers(a api.API[*api.Request, *api.Response], mux Mux, specs []*v1.VirtualHostSpec, notFound http.Handler) (err error) {
 	defer func() {
 		if err != nil {
 			return
@@ -62,17 +44,16 @@ func registerHandlers(a api.API[*api.Request, *api.Response], mux Mux, specs []*
 		}
 	}()
 
-	handlers = map[string]http.Handler{}
 	for _, vhSpec := range specs {
 		middleware, err := api.ReferTypedObjects[core.Middleware](a, vhSpec.Middleware...)
 		if err != nil {
-			return nil, core.ErrCoreGenCreateComponent.WithStack(err, map[string]any{"reason": "failed to get middleware"})
+			return core.ErrCoreGenCreateComponent.WithStack(err, map[string]any{"reason": "failed to get middleware"})
 		}
 
 		for _, hSpec := range vhSpec.Handlers {
 			methods, paths, handler, err := utilhttp.Handler(a, hSpec)
 			if err != nil {
-				return nil, core.ErrCoreGenCreateComponent.WithStack(err, map[string]any{"reason": "failed to create handler"})
+				return core.ErrCoreGenCreateComponent.WithStack(err, map[string]any{"reason": "failed to create handler"})
 			}
 			if len(paths) == 0 {
 				paths = append(paths, hSpec.Pattern)
@@ -90,23 +71,28 @@ func registerHandlers(a api.API[*api.Request, *api.Response], mux Mux, specs []*
 					methods = intersectionString(methods, utilhttp.Methods(vhSpec.Methods))
 				}
 			}
-			for _, pattern := range generatePatterns(methods, vhSpec.Hosts, paths) {
+			for _, pattern := range generatePatterns(vhSpec.Hosts, paths) {
 				h := utilhttp.MiddlewareChain(middleware, handler)
-				mux.Handle(pattern, h)
-				handlers[pattern] = h
+				mux.Handle(pattern, &methodCheckHandler{
+					handler:          h,
+					methodNotAllowed: notFound,
+					allowMethods:     methods,
+					allowAll:         len(methods) == 0,
+				})
 			}
-
-			// Do not allow HEAD automatically routed to GET.  https://github.com/aileron-gateway/aileron-gateway/issues/33
-			if slices.Contains(methods, http.MethodGet) && !slices.Contains(methods, http.MethodHead) {
-				for _, pattern := range generatePatterns([]string{http.MethodHead}, vhSpec.Hosts, paths) {
-					mux.Handle(pattern, notFound)
-					handlers[pattern] = notFound
-				}
-			}
+		}
+		for _, pattern := range generatePatterns(vhSpec.Hosts, nil) {
+			registerNotFound(mux, pattern, notFound)
 		}
 	}
 
-	return handlers, nil
+	registerNotFound(mux, "/", notFound)
+	return nil
+}
+
+func registerNotFound(mux Mux, pattern string, h http.Handler) {
+	defer func() { recover() }()
+	mux.Handle(pattern, h)
 }
 
 // IntersectionString returns intersection of the two given set.
@@ -133,30 +119,35 @@ func intersectionString(set1, set2 []string) []string {
 }
 
 // generatePatterns returns pattern for serve mux.
-// Returned patterns contains the all available combinations
-// of the given methods, hosts,paths.
-func generatePatterns(methods, hosts []string, paths []string) []string {
-	if len(methods) == 0 {
-		methods = []string{""}
-	}
+func generatePatterns(hosts []string, paths []string) []string {
 	if len(hosts) == 0 {
 		hosts = []string{""}
 	}
 	if len(paths) == 0 {
 		paths = []string{"/"}
 	}
-
-	patterns := make([]string, 0, len(methods)*len(hosts)*len(paths))
-	for _, m := range methods {
-		for _, h := range hosts {
-			for _, p := range paths {
-				p = "/" + strings.TrimPrefix(p, "/")
-				pattern := m + " " + h + p // "[METHOD ][HOST]/[PATH]" https://pkg.go.dev/net/http#ServeMux
-				patterns = append(patterns, strings.Trim(pattern, " "))
-			}
+	patterns := make([]string, 0, len(hosts)*len(paths))
+	for _, h := range hosts {
+		for _, p := range paths {
+			p = "/" + strings.TrimPrefix(p, "/")
+			patterns = append(patterns, h+p) // "[HOST]/[PATH]" https://pkg.go.dev/net/http#ServeMux
 		}
 	}
+	slices.Sort(patterns)           // slices.Compact require sorts.
+	return slices.Compact(patterns) // Remove duplicates.
+}
 
-	slices.Sort(patterns)                        // slices.Compact require sorts.
-	return slices.Clip(slices.Compact(patterns)) // Remove duplicates.
+type methodCheckHandler struct {
+	handler          http.Handler
+	methodNotAllowed http.Handler
+	allowMethods     []string // Allowed methods list.
+	allowAll         bool     // Allow all HTTP methods.
+}
+
+func (h methodCheckHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.allowAll || slices.Contains(h.allowMethods, r.Method) {
+		h.handler.ServeHTTP(w, r)
+		return
+	}
+	h.methodNotAllowed.ServeHTTP(w, r)
 }

--- a/core/httpserver/mux_internal_test.go
+++ b/core/httpserver/mux_internal_test.go
@@ -138,8 +138,10 @@ func TestRegisterHandlers(t *testing.T) {
 				},
 			},
 			&action{
-				handlers: map[string]http.Handler{},
-				err:      nil,
+				handlers: map[string]http.Handler{
+					"/": notFound,
+				},
+				err: nil,
 			},
 		),
 		gen(
@@ -175,6 +177,7 @@ func TestRegisterHandlers(t *testing.T) {
 				handlers: map[string]http.Handler{
 					"/test1":  h2,
 					"/test2/": h2,
+					"/":       notFound,
 				},
 				err: nil,
 			},
@@ -191,7 +194,7 @@ func TestRegisterHandlers(t *testing.T) {
 				},
 			},
 			&action{
-				handlers: map[string]http.Handler{"GET /": h3, "HEAD /": h3},
+				handlers: map[string]http.Handler{"/": h3},
 				err:      nil,
 			},
 		),
@@ -208,8 +211,9 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET /test1": h4, "HEAD /test1": h4,
-					"GET /test2/": h4, "HEAD /test2/": h4,
+					"/test1":  h4,
+					"/test2/": h4,
+					"/":       notFound,
 				},
 				err: nil,
 			},
@@ -230,6 +234,8 @@ func TestRegisterHandlers(t *testing.T) {
 			&action{
 				handlers: map[string]http.Handler{
 					"example.com/pattern": h1,
+					"example.com/":        notFound,
+					"/":                   notFound,
 				},
 				err: nil,
 			},
@@ -251,6 +257,8 @@ func TestRegisterHandlers(t *testing.T) {
 				handlers: map[string]http.Handler{
 					"example.com/pattern/test1":  h2,
 					"example.com/pattern/test2/": h2,
+					"example.com/":               notFound,
+					"/":                          notFound,
 				},
 				err: nil,
 			},
@@ -270,7 +278,9 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern": h3, "HEAD example.com/pattern": h3,
+					"example.com/pattern": h3,
+					"example.com/":        notFound,
+					"/":                   notFound,
 				},
 				err: nil,
 			},
@@ -290,8 +300,10 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern/test1": h4, "HEAD example.com/pattern/test1": h4,
-					"GET example.com/pattern/test2/": h4, "HEAD example.com/pattern/test2/": h4,
+					"example.com/pattern/test1":  h4,
+					"example.com/pattern/test2/": h4,
+					"example.com/":               notFound,
+					"/":                          notFound,
 				},
 				err: nil,
 			},
@@ -310,7 +322,7 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET /": h1, "DELETE /": h1, "HEAD /": notFound,
+					"/": h1,
 				},
 				err: nil,
 			},
@@ -329,8 +341,9 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET /test1": h2, "DELETE /test1": h2, "HEAD /test1": notFound,
-					"GET /test2/": h2, "DELETE /test2/": h2, "HEAD /test2/": notFound,
+					"/test1":  h2,
+					"/test2/": h2,
+					"/":       notFound,
 				},
 				err: nil,
 			},
@@ -349,8 +362,7 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET /":  h3,
-					"HEAD /": notFound,
+					"/": h3,
 				},
 				err: nil,
 			},
@@ -369,8 +381,9 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET /test1": h4, "HEAD /test1": notFound,
-					"GET /test2/": h4, "HEAD /test2/": notFound,
+					"/test1":  h4,
+					"/test2/": h4,
+					"/":       notFound,
 				},
 				err: nil,
 			},
@@ -391,8 +404,9 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern": h1, "DELETE example.com/pattern": h1,
-					"HEAD example.com/pattern": notFound,
+					"example.com/pattern": h1,
+					"example.com/":        notFound,
+					"/":                   notFound,
 				},
 				err: nil,
 			},
@@ -413,8 +427,10 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern/test1": h2, "DELETE example.com/pattern/test1": h2, "HEAD example.com/pattern/test1": notFound,
-					"GET example.com/pattern/test2/": h2, "DELETE example.com/pattern/test2/": h2, "HEAD example.com/pattern/test2/": notFound,
+					"example.com/pattern/test1":  h2,
+					"example.com/pattern/test2/": h2,
+					"example.com/":               notFound,
+					"/":                          notFound,
 				},
 				err: nil,
 			},
@@ -435,7 +451,9 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern": h3, "HEAD example.com/pattern": notFound,
+					"example.com/pattern": h3,
+					"example.com/":        notFound,
+					"/":                   notFound,
 				},
 				err: nil,
 			},
@@ -456,8 +474,10 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern/test1": h4, "HEAD example.com/pattern/test1": notFound,
-					"GET example.com/pattern/test2/": h4, "HEAD example.com/pattern/test2/": notFound,
+					"example.com/pattern/test1":  h4,
+					"example.com/pattern/test2/": h4,
+					"example.com/":               notFound,
+					"/":                          notFound,
 				},
 				err: nil,
 			},
@@ -481,8 +501,10 @@ func TestRegisterHandlers(t *testing.T) {
 			},
 			&action{
 				handlers: map[string]http.Handler{
-					"GET example.com/pattern/test1": m.Middleware(h4), "HEAD example.com/pattern/test1": notFound,
-					"GET example.com/pattern/test2/": m.Middleware(h4), "HEAD example.com/pattern/test2/": notFound,
+					"example.com/pattern/test1":  m.Middleware(h4),
+					"example.com/pattern/test2/": m.Middleware(h4),
+					"example.com/":               notFound,
+					"/":                          notFound,
 				},
 				err: nil,
 			},
@@ -492,7 +514,7 @@ func TestRegisterHandlers(t *testing.T) {
 			&condition{
 				specs: []*v1.VirtualHostSpec{
 					{
-						Pattern: "GET GET /test",
+						Pattern: "/{foo.../",
 						Hosts:   []string{""},
 						Handlers: []*v1.HTTPHandlerSpec{
 							{Handler: testResourceRef("handler1")},
@@ -542,13 +564,12 @@ func TestRegisterHandlers(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			mux := &testMux{
 				Mux: &http.ServeMux{},
 				hs:  make(map[string]http.Handler),
 			}
-			handlers, err := registerHandlers(testAPI, mux, tt.C.specs, notFound)
+			err := registerHandlers(testAPI, mux, tt.C.specs, notFound)
 			testutil.DiffError(t, tt.A.err, tt.A.errPattern, err)
 
 			opts := []cmp.Option{
@@ -565,6 +586,14 @@ func TestRegisterHandlers(t *testing.T) {
 					yh := wy.Result().Header
 					return slices.Equal(xh["Handler"], yh["Handler"]) && slices.Equal(xh["Middleware"], yh["Middleware"])
 				}),
+			}
+			handlers := map[string]http.Handler{}
+			for p, h := range mux.hs {
+				if h, ok := h.(*methodCheckHandler); ok {
+					handlers[p] = h.handler
+				} else {
+					handlers[p] = notFound
+				}
 			}
 			testutil.Diff(t, tt.A.handlers, handlers, opts...)
 			testutil.Diff(t, len(tt.A.handlers), len(handlers))
@@ -637,9 +666,8 @@ func TestIntersectionString(t *testing.T) {
 
 func TestGeneratePatterns(t *testing.T) {
 	type condition struct {
-		methods []string
-		hosts   []string
-		paths   []string
+		hosts []string
+		paths []string
 	}
 
 	type action struct {
@@ -649,358 +677,113 @@ func TestGeneratePatterns(t *testing.T) {
 	gen := testutil.NewCase[*condition, *action]
 	testCases := []*testutil.Case[*condition, *action]{
 		gen(
-			"0 method, 0 hosts, 0 paths",
+			"0 hosts, 0 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{},
-				paths:   []string{},
+				hosts: []string{},
+				paths: []string{},
 			},
 			&action{
 				patterns: []string{"/"},
 			},
 		),
 		gen(
-			"0 method, 0 hosts, 1 paths",
+			"0 hosts, 1 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{},
-				paths:   []string{"/foo"},
+				hosts: []string{},
+				paths: []string{"/foo"},
 			},
 			&action{
 				patterns: []string{"/foo"},
 			},
 		),
 		gen(
-			"0 method, 0 hosts, 2 paths",
+			"0 hosts, 2 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{},
-				paths:   []string{"/foo", "bar"},
+				hosts: []string{},
+				paths: []string{"/foo", "bar"},
 			},
 			&action{
 				patterns: []string{"/foo", "/bar"},
 			},
 		),
 		gen(
-			"0 method, 1 hosts, 0 paths",
+			"1 hosts, 0 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com"},
-				paths:   []string{},
+				hosts: []string{"foo.com"},
+				paths: []string{},
 			},
 			&action{
 				patterns: []string{"foo.com/"},
 			},
 		),
 		gen(
-			"0 method, 1 hosts, 1 paths",
+			"1 hosts, 1 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com"},
-				paths:   []string{"/foo"},
+				hosts: []string{"foo.com"},
+				paths: []string{"/foo"},
 			},
 			&action{
 				patterns: []string{"foo.com/foo"},
 			},
 		),
 		gen(
-			"0 method, 1 hosts, 2 paths",
+			"1 hosts, 2 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com"},
-				paths:   []string{"/foo", "bar"},
+				hosts: []string{"foo.com"},
+				paths: []string{"/foo", "bar"},
 			},
 			&action{
 				patterns: []string{"foo.com/foo", "foo.com/bar"},
 			},
 		),
 		gen(
-			"0 method, 2 hosts, 0 paths",
+			"2 hosts, 0 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{},
+				hosts: []string{"foo.com", "bar.com"},
+				paths: []string{},
 			},
 			&action{
 				patterns: []string{"foo.com/", "bar.com/"},
 			},
 		),
 		gen(
-			"0 method, 2 hosts, 1 paths",
+			"2 hosts, 1 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{"/foo"},
+				hosts: []string{"foo.com", "bar.com"},
+				paths: []string{"/foo"},
 			},
 			&action{
 				patterns: []string{"foo.com/foo", "bar.com/foo"},
 			},
 		),
 		gen(
-			"0 method, 2 hosts, 2 paths",
+			"2 hosts, 2 paths",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{"/foo", "bar"},
+				hosts: []string{"foo.com", "bar.com"},
+				paths: []string{"/foo", "bar"},
 			},
 			&action{
 				patterns: []string{"foo.com/foo", "foo.com/bar", "bar.com/foo", "bar.com/bar"},
 			},
 		),
 		gen(
-			"1 method, 0 hosts, 0 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET /"},
-			},
-		),
-		gen(
-			"1 method, 0 hosts, 1 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{},
-				paths:   []string{"/foo"},
-			},
-			&action{
-				patterns: []string{"GET /foo"},
-			},
-		),
-		gen(
-			"1 method, 0 hosts, 2 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{},
-				paths:   []string{"/foo", "bar"},
-			},
-			&action{
-				patterns: []string{"GET /foo", "GET /bar"},
-			},
-		),
-		gen(
-			"1 method, 1 hosts, 0 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com"},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET foo.com/"},
-			},
-		),
-		gen(
-			"1 method, 1 hosts, 1 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com"},
-				paths:   []string{"/foo"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo"},
-			},
-		),
-		gen(
-			"1 method, 1 hosts, 2 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com"},
-				paths:   []string{"/foo", "bar"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo", "GET foo.com/bar"},
-			},
-		),
-		gen(
-			"1 method, 2 hosts, 0 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET foo.com/", "GET bar.com/"},
-			},
-		),
-		gen(
-			"1 method, 2 hosts, 1 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{"/foo"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo", "GET bar.com/foo"},
-			},
-		),
-		gen(
-			"1 method, 2 hosts, 2 paths",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{"/foo", "bar"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo", "GET foo.com/bar", "GET bar.com/foo", "GET bar.com/bar"},
-			},
-		),
-		gen(
-			"2 method, 0 hosts, 0 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET /", "POST /"},
-			},
-		),
-		gen(
-			"2 method, 0 hosts, 1 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{},
-				paths:   []string{"/foo"},
-			},
-			&action{
-				patterns: []string{"GET /foo", "POST /foo"},
-			},
-		),
-		gen(
-			"2 method, 0 hosts, 2 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{},
-				paths:   []string{"/foo", "bar"},
-			},
-			&action{
-				patterns: []string{"GET /foo", "GET /bar", "POST /foo", "POST /bar"},
-			},
-		),
-		gen(
-			"2 method, 1 hosts, 0 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{"foo.com"},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET foo.com/", "POST foo.com/"},
-			},
-		),
-		gen(
-			"2 method, 1 hosts, 1 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{"foo.com"},
-				paths:   []string{"/foo"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo", "POST foo.com/foo"},
-			},
-		),
-		gen(
-			"2 method, 1 hosts, 2 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{"foo.com"},
-				paths:   []string{"/foo", "bar"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo", "GET foo.com/bar", "POST foo.com/foo", "POST foo.com/bar"},
-			},
-		),
-		gen(
-			"2 method, 2 hosts, 0 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET foo.com/", "GET bar.com/", "POST foo.com/", "POST bar.com/"},
-			},
-		),
-		gen(
-			"2 method, 2 hosts, 1 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{"/foo"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo", "GET bar.com/foo", "POST foo.com/foo", "POST bar.com/foo"},
-			},
-		),
-		gen(
-			"2 method, 2 hosts, 2 paths",
-			&condition{
-				methods: []string{http.MethodGet, http.MethodPost},
-				hosts:   []string{"foo.com", "bar.com"},
-				paths:   []string{"/foo", "bar"},
-			},
-			&action{
-				patterns: []string{
-					"GET foo.com/foo", "GET foo.com/bar", "GET bar.com/foo", "GET bar.com/bar",
-					"POST foo.com/foo", "POST foo.com/bar", "POST bar.com/foo", "POST bar.com/bar",
-				},
-			},
-		),
-		gen(
 			"invalid pattern path",
 			&condition{
-				methods: []string{},
-				hosts:   []string{},
-				paths:   []string{"foo.com/foo"},
+				hosts: []string{},
+				paths: []string{"foo.com/foo"},
 			},
 			&action{
 				patterns: []string{"/foo.com/foo"}, // Unexpected pattern.
 			},
 		),
 		gen(
-			"invalid pattern method+path",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{},
-				paths:   []string{"foo.com/foo"},
-			},
-			&action{
-				patterns: []string{"GET /foo.com/foo"}, // Unexpected pattern.
-			},
-		),
-		gen(
 			"valid pattern host",
 			&condition{
-				methods: []string{},
-				hosts:   []string{"foo.com/foo"},
-				paths:   []string{},
+				hosts: []string{"foo.com/foo"},
+				paths: []string{},
 			},
 			&action{
 				patterns: []string{"foo.com/foo/"}, // Irregular setting, but valid pattern.
-			},
-		),
-		gen(
-			"valid pattern method+host",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com/foo"},
-				paths:   []string{},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo/"}, // Irregular setting, but valid pattern.
-			},
-		),
-		gen(
-			"valid pattern method+host+path",
-			&condition{
-				methods: []string{http.MethodGet},
-				hosts:   []string{"foo.com/foo"},
-				paths:   []string{"bar"},
-			},
-			&action{
-				patterns: []string{"GET foo.com/foo/bar"}, // Irregular setting, but valid pattern.
 			},
 		),
 	}
@@ -1008,7 +791,7 @@ func TestGeneratePatterns(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
-			patterns := generatePatterns(tt.C.methods, tt.C.hosts, tt.C.paths)
+			patterns := generatePatterns(tt.C.hosts, tt.C.paths)
 
 			opts := []cmp.Option{
 				cmpopts.SortSlices(func(x, y string) bool { return x > y }),

--- a/internal/testutil/util.go
+++ b/internal/testutil/util.go
@@ -87,7 +87,7 @@ func structTypes(v reflect.Value, m map[reflect.Type]struct{}) {
 		return
 	}
 	switch v.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if !v.IsNil() {
 			structTypes(v.Elem(), m)
 		}
@@ -105,7 +105,7 @@ func structTypes(v reflect.Value, m map[reflect.Type]struct{}) {
 		}
 	case reflect.Struct:
 		m[v.Type()] = struct{}{}
-		for i := 0; i < v.NumField(); i++ {
+		for i := range v.NumField() {
 			structTypes(v.Field(i), m)
 		}
 	}


### PR DESCRIPTION
## What type of PR is this?

- [ ] new feature
- [ ] enhance feature
- [ ] refactoring, performance tuning
- [x] bug fix
- [ ] security fix
- [ ] testing
- [ ] documentation
- [ ] release
- [ ] others

## Related issues

<!--
Fixes `#<issue number>` or `(paste link of issue)`
Closes `#<issue number>` or `(paste link of issue)`
-->

## Does this PR break user interface?

- [ ] Yes <!-- Fill the release-note -->
  - [ ] Did you add [CHANGELOG](CHANGELOG/)?
  - [ ] Did you add migration guides in [CHANGELOG](CHANGELOG/)?
- [x] No
  - [ ] Did you add [CHANGELOG](CHANGELOG/)? (if necessary)

## Description

Before this fix, `GET /foo`, `HEAD /foo (NotFound handler)`  and `/` conflicts because of the auto registration of NotFound handler.
This PR fixes the confliction.

In this PR, ServeMux won't be used for http method routing.
It will be used only for domain and path routing.
Methods' allow/deny will be checked after handlers were dispached by the ServeMux.
This PR solves the confliction problem and makes the configuration more intuitive.

## Notes for reviewers
